### PR TITLE
Bring back logrotate

### DIFF
--- a/files/infrastructure/environments/development/modules/profile/manifests/base.pp
+++ b/files/infrastructure/environments/development/modules/profile/manifests/base.pp
@@ -1,20 +1,43 @@
 class profile::base {
-  # Example of resource declaration
+  # Resource declaration
   # This doesn't really merit the creation of a new class,
   # but it could grow to the point where a class that
   # manages these (or one class each) could be used instead.
   # The emphasis is on iterating quickly.
-
+  # Ensure that the packages wget and vim-common are installed:
   package { ['wget', 'vim-common']:
     ensure => present,
   }
 
-  # Example of class declaration using include
+  # The following example includes a class to manage host
+  # entries in /etc/hosts for all your agent nodes
   include classroom::agent::hosts
 
-  # Example of resource-like class declaration
-  class { 'ssh::client':
-    client_package => 'openssh-clients',
+  # Class declaration using 'include'
+  # use appropriate syntax to declare the class 'ssh::client'
+  include ssh::client
+
+  # Resource-like class declaration
+  # Declare the appropriate class to manage logrotate here
+  # Configure logrotate to preserve logs for 180 days, and
+  # to compress the logs.
+
+  class { 'logrotate':
+    ensure => present,
+    config => {
+      maxage   => 180,
+      compress => true,
+    }
+  }
+
+  # declaring a defined resource type
+  # declare a new logrotate rule for /var/log/messages
+  # ensure that this log is rotated every week.
+
+  logrotate::rule { 'messages':
+    path         => '/var/log/messages',
+    rotate_every => 'week',
+    postrotate   => '/usr/bin/killall -HUP syslogd',
   }
 
 }

--- a/files/infrastructure/environments/production/modules/profile/manifests/base.pp
+++ b/files/infrastructure/environments/production/modules/profile/manifests/base.pp
@@ -6,16 +6,38 @@ class profile::base {
   # The emphasis is on iterating quickly.
   # Ensure that the packages wget and vim-common are installed:
   package { ['wget', 'vim-common']:
-    ensure => 
+    ensure => present,
   }
 
-  # Class declaration using include
-  # use appropriate syntax to declare the class
+  # The following example includes a class to manage host
+  # entries in /etc/hosts for all your agent nodes
   include classroom::agent::hosts
+
+  # Class declaration using 'include'
+  # use appropriate syntax to declare the class 'ssh::client'
+  include 
+
   # Resource-like class declaration
-  # Declare the appropriate class to manage SSH clients below:
+  # Declare the appropriate class to manage logrotate here
+  # Configure logrotate to preserve logs for 180 days, and
+  # to compress the logs.
 
   class { '':
+    ensure => present,
+    config => {
+      maxage   => ,
+      compress => ,
+    }
+  }
+
+  # declaring a defined resource type
+  # declare a new logrotate rule for /var/log/messages
+  # ensure that this log is rotated every week.
+
+  logrotate::rule { 'messages':
+    path         => '',
+    rotate_every => '',
+    postrotate   => '/usr/bin/killall -HUP syslogd',
   }
 
 }


### PR DESCRIPTION
COURSES-1483
The yo61-logrotate module fixes the issues that rodjek-logrotate had.
I added the logrotate defined type and class declaration back into the
Lab for infrastructure design. This commit add the required code to the
starter code provided for the course.
